### PR TITLE
fix(hits): display all the elements in all categories

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -253,7 +253,7 @@ search.addWidget(
 search.addWidget(
   instantsearch.widgets.hits({
     container: '.alg-communityprojects__hits.is',
-    hitsPerPage: 10,
+    hitsPerPage: 30,
     templates:{
       item: templates.hitTemplate,
       empty: templates.noHits


### PR DESCRIPTION
hitsPerPage was set to 10, API clients have more than 10 elements.