### PR TITLE
fix(links): use aria-label instead of title

### DIFF
--- a/src/index.haml
+++ b/src/index.haml
@@ -90,13 +90,13 @@
             .alg-communityareas__area.text-center.p-large
               %h3.text-lg Documentation
               %p.m-l-r-auto Jump to the official Algolia documentation, guides and tutorials.
-              %a.btn-lg.btn.btn-static-primary.elevation1{href: "https://algolia.com/doc", title: "Algolia documentation"}
+              %a.btn-lg.btn.btn-static-primary.elevation1{href: "https://algolia.com/doc", aria_label: "Algolia documentation"}
                 Read the docs
                 <svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><use xlink:href="#icon-arrow"></use></svg>
             .alg-communityareas__area.text-center.p-large
               %h3.text-lg Community Forum
               %p.m-l-r-auto Ask questions and get the latest news. <br>Don't miss the Show & Tell category.
-              %a.btn-lg.btn.btn-static-secondary.elevation1{href: "https://discourse.algolia.com/", title: "Algolia Discourse Forum"}
+              %a.btn-lg.btn.btn-static-secondary.elevation1{href: "https://discourse.algolia.com/", aria_label: "Algolia Discourse Forum"}
                 Browse the forum
                 <svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><use xlink:href="#icon-arrow"></use></svg>
 
@@ -127,7 +127,7 @@
             .col-md-6.text-right
               .spacer64.hidden-xs
               .spacer32
-              %a.btn.btn-static-dark{href: "https://discourse.algolia.com/", alt: "Visit the Discourse Forum"}
+              %a.btn.btn-static-dark{href: "https://discourse.algolia.com/", aria_label: "Visit the Discourse Forum"}
                 Browse the forum
                 <svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><use xlink:href="#icon-arrow"></use></svg>
               .spacer8


### PR DESCRIPTION
This is because one of the links used `alt` (W3C error), I checked what the best option is, and according to research in [this article](https://www.deque.com/blog/text-links-practices-screen-readers/) the best way to get both texts to be spoken is by using `aria-label`