### PR TITLE
Fix #41

### DIFF
--- a/src/scss/_site.scss
+++ b/src/scss/_site.scss
@@ -637,6 +637,7 @@ $browserExtension: $java;
         display: flex;
         flex-flow: column wrap;
         place-items: center;
+        align-items: center;
         top: 0px;
         width: 78px;
         height: 78px;


### PR DESCRIPTION
`place-items: center` isn't recognized by mobile devices yet. Let's keep it plus align items. 